### PR TITLE
Fix duplicate chunk name

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -77,7 +77,7 @@ Simply add the following lines into your Rmd,
 learnrhash::decoder_logic()
 ```
 
-`r ''````{r encode, echo=FALSE}
+`r ''````{r decode, echo=FALSE}
 learnrhash::decoder_ui()
 ```
 ````


### PR DESCRIPTION
If the README lines are copy/pasted into a tutorial, an error results, since the chunk name 'encode' appears twice.