### PR TITLE
Generalize extract behavior across learnr versions?

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -42,7 +42,7 @@ extract_hash = function(df, hash = "hash") {
     ) %>%
     tidyr::unnest_longer(.data[[hash]]) %>%
     tidyr::unnest_wider(.data[[hash]]) %>%
-    dplyr::relocate(.data[["label"]], .before="type")
+    dplyr::relocate(.data[["data"]], .before="type")
 
   if (is.null(d[["data"]]))
     d$data = list(NULL)
@@ -54,12 +54,12 @@ extract_hash = function(df, hash = "hash") {
 #' @export
 extract_exercises = function(df, hash = "hash") {
   extract_hash(df, hash) %>%
-    dplyr::filter(.data[["type"]] == "exercise")
+    dplyr::filter(startsWith(.data[["type"]], "exercise"))
 }
 
 #' @rdname extract
 #' @export
 extract_questions = function(df, hash = "hash") {
   extract_hash(df, hash) %>%
-    dplyr::filter(.data[["type"]] == "question")
+    dplyr::filter(startsWith(.data[["type"]], "question"))
 }

--- a/R/extract.R
+++ b/R/extract.R
@@ -41,8 +41,12 @@ extract_hash = function(df, hash = "hash") {
       hash = lapply(.data[[hash]], fix_empty_state_obj)
     ) %>%
     tidyr::unnest_longer(.data[[hash]]) %>%
-    tidyr::unnest_wider(.data[[hash]]) %>%
-    dplyr::relocate(.data[["data"]], .before="type")
+    tidyr::unnest_wider(.data[[hash]])
+
+  if ("label" %in% names(d)) {
+    d = d %>%
+      dplyr::relocate(.data[["label"]], .before="type")
+  }
 
   if (is.null(d[["data"]]))
     d$data = list(NULL)

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -50,7 +50,7 @@ test_that("test extract w/ empty data", {
   exs = extract_exercises(df, "hash")
 
   expect_equal(dim(all), c(1,5))
-  expect_true(all(c("student","student_id", "id", "data", "type") == names(all)))
+  expect_true(all(c("student","student_id", "id", "type", "data") == names(all)))
 
 
   df2 = tibble::tibble(
@@ -65,7 +65,7 @@ test_that("test extract w/ empty data", {
 
 
   expect_equal(dim(all2), c(2,5))
-  expect_true(all(c("student","student_id", "id", "data", "type") == names(all2)))
+  expect_true(all(c("student","student_id", "id", "type", "data") == names(all2)))
 })
 
 

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -50,7 +50,7 @@ test_that("test extract w/ empty data", {
   exs = extract_exercises(df, "hash")
 
   expect_equal(dim(all), c(1,5))
-  expect_true(all(c("student","student_id", "id", "type", "data") == names(all)))
+  expect_true(all(c("student","student_id", "id", "data", "type") == names(all)))
 
 
   df2 = tibble::tibble(
@@ -65,7 +65,7 @@ test_that("test extract w/ empty data", {
 
 
   expect_equal(dim(all2), c(2,5))
-  expect_true(all(c("student","student_id", "id", "type", "data") == names(all2)))
+  expect_true(all(c("student","student_id", "id", "data", "type") == names(all2)))
 })
 
 


### PR DESCRIPTION
Hi Colin/other maintainers,

First off, this package has been critical in helping me set up an auto-grading pipeline for an introductory R course I TA'd for, so thank you!

I originally wrote that pipeline in fall 2021 and had hash creation/extraction code working with the then-newest development version of learnr and learnrhash. The relevant learnr tutorial homework assignments are hosted online through a shinyapps.io instance.

This year's class is using the same homework instance (if it ain't broke, don't fix it?), which means the hashes are being _encoded_ using an older version of learnr/learnrhash, but then _decoded/extracted_ back in R using the newest versions of both (specifically, `learnr=0.10.6.9`). (There is a new TA working on the course, so I'm refreshing the auto-grading scripts assuming they will be installing the newest available versions of packages.) I imagine this use case might apply for others as well.

I noticed that my older encoded hashes would not extract using the newest version of learnrhash--`extract_exercises()` threw an error that appeared to source from `extract_hash()`:

```r
Error in `.data[["label"]]`:
! Column `label` not found in `.data`.
```

Further, the testthat tests, which helpfully have the hashes hard-coded in, also fail with the same error.

Accordingly, I modified the changes from #19 to call `dplyr::relocate()` on either the `label` or the `id` column, whichever _exists._ 

Once I changed that, my older hashes were still giving me an issue--they would return tibbles length 0 from `extract_exercises()` because they still had `type == 'exercise_submission'` instead of the newer learnr label, `type == 'exercise'`. So, for that, I figured it might be safe to generalize the `filter()` logic in `extract_exercises()` and `extract_questions()` to filter by `startsWith()` instead of strict `==`. That way, hashes from older and newer versions should both work presuming the types still start with `'question'` and `'exercise'` respectively.

The tests pass now, and my older hashes extract again. I'm not 100% sure if this also incidentally resolves #18 , but based on the description in that issue, I think it may?

Hope this helps!